### PR TITLE
fix(md2pdf): cache engine selection and correct docker exec usage

### DIFF
--- a/commands/md2pdf/src/main/kotlin/com/bepiscorp/ktools/commands/md2pdf/DockerBridge.kt
+++ b/commands/md2pdf/src/main/kotlin/com/bepiscorp/ktools/commands/md2pdf/DockerBridge.kt
@@ -46,7 +46,7 @@ class DockerBridge {
                     inputFile.writeText(inputContent)
 
                     // Execute conversion via Docker
-                    val success = executeDockerConversion(containerId, tempDir, inputFile, outputFile, options)
+                    val success = executeDockerConversion(containerId, inputFile, outputFile, options)
 
                     if (success && outputFile.exists()) {
                         if (output.path == "-") {
@@ -201,20 +201,35 @@ class DockerBridge {
 
     private suspend fun executeDockerConversion(
         containerId: String,
-        tempDir: File,
         inputFile: File,
         outputFile: File,
         options: Map<String, Any>
     ): Boolean =
         withContext(Dispatchers.IO) {
+            // Copy input file into container
+            val copyIn = ProcessBuilder(
+                "docker",
+                "cp",
+                inputFile.absolutePath,
+                "$containerId:/workspace/${inputFile.name}"
+            ).redirectErrorStream(true)
+                .start()
+
+            copyIn.waitFor()
+            if (copyIn.exitValue() != 0) {
+                val err = copyIn.inputStream.bufferedReader().readText()
+                throw RuntimeException("Failed to copy input into container: $err")
+            }
+
             // Build conversion command
             val command = buildMd2PdfCommand(inputFile.name, outputFile.name, options)
             val dockerCommand = mutableListOf(
-                "docker", "exec",
-                "-w", "/workspace",
-                "-v", "${tempDir.absolutePath}:/workspace"
+                "docker",
+                "exec",
+                "-w",
+                "/workspace",
+                containerId
             )
-            dockerCommand.add(containerId)
             dockerCommand.addAll(command)
 
             // Execute conversion
@@ -232,6 +247,21 @@ class DockerBridge {
 
             if (exitCode != 0) {
                 throw RuntimeException("Docker md2pdf conversion failed: $output")
+            }
+
+            // Copy output file back to host
+            val copyOut = ProcessBuilder(
+                "docker",
+                "cp",
+                "$containerId:/workspace/${outputFile.name}",
+                outputFile.absolutePath
+            ).redirectErrorStream(true)
+                .start()
+
+            copyOut.waitFor()
+            if (copyOut.exitValue() != 0) {
+                val err = copyOut.inputStream.bufferedReader().readText()
+                throw RuntimeException("Failed to copy output from container: $err")
             }
 
             return@withContext outputFile.exists()

--- a/commands/md2pdf/src/main/kotlin/com/bepiscorp/ktools/commands/md2pdf/Md2PdfProcessor.kt
+++ b/commands/md2pdf/src/main/kotlin/com/bepiscorp/ktools/commands/md2pdf/Md2PdfProcessor.kt
@@ -73,6 +73,7 @@ class Md2PdfProcessor(
 
     /** Convert markdown files according to the options. */
     fun convert(options: Md2PdfOptions): ProcessingResult {
+        var engineName = engine
         return try {
             // Validate options
             validateOptions(options)
@@ -82,6 +83,8 @@ class Md2PdfProcessor(
 
             // Select and initialize engine
             val engineInfo = selectEngine()
+            engineName = engineInfo.name
+            activeEngine = engineInfo
             if (!quiet) log.info { "Using ${engineInfo.name} mode" }
 
             // Process inputs
@@ -132,7 +135,7 @@ class Md2PdfProcessor(
             ProcessingResult(
                 success = false,
                 message = e.message ?: "Validation failed",
-                engine = getActiveEngine(),
+                engine = engineName,
                 exitCode = 1,
                 hint = e.hint
             )
@@ -140,7 +143,7 @@ class Md2PdfProcessor(
             ProcessingResult(
                 success = false,
                 message = e.message ?: "Engine error",
-                engine = getActiveEngine(),
+                engine = engineName,
                 exitCode = e.exitCode,
                 hint = e.hint
             )
@@ -149,7 +152,7 @@ class Md2PdfProcessor(
             ProcessingResult(
                 success = false,
                 message = "Unexpected error: ${e.message}",
-                engine = getActiveEngine(),
+                engine = engineName,
                 exitCode = 2,
                 hint = "Run with --verbose for more details"
             )


### PR DESCRIPTION
## Summary
- avoid re-running engine detection by caching the selected engine for error responses
- copy conversion files with `docker cp` instead of unsupported `-v` flag on `docker exec`

## Testing
- `./gradlew spotlessCheck --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68bd7d2db92883298398519438ceb095